### PR TITLE
Made @package optional if there is a namespace

### DIFF
--- a/PHP/BoxUK/Sniffs/Commenting/PackageAnnotationSniff.php
+++ b/PHP/BoxUK/Sniffs/Commenting/PackageAnnotationSniff.php
@@ -58,7 +58,7 @@ class BoxUK_Sniffs_Commenting_PackageAnnotationSniff implements PHP_CodeSniffer_
             // try and fail fast, if we hit much else apart from the namespace
             // then there can't be a namespace
             if ( $value['type'] == 'T_STRING' ) {
-                return false;
+                break;
             }
             
         }

--- a/PHP/BoxUK/Sniffs/Commenting/PackageAnnotationSniff.php
+++ b/PHP/BoxUK/Sniffs/Commenting/PackageAnnotationSniff.php
@@ -33,19 +33,47 @@ class BoxUK_Sniffs_Commenting_PackageAnnotationSniff implements PHP_CodeSniffer_
         }
         
         else {
-            $this->sniffForPackage( $phpcsFile, $tokens, $index, $stackPtr );
+            if ( !$this->classIsNamespaced($tokens) ) {
+                $this->sniffForPackage( $phpcsFile, $tokens, $index, $stackPtr );
+            }
         }
 
     }
+    
+    /**
+     * Indicates if the file we're checking is namespaced
+     * 
+     * @param array $tokens The tokens that make up the file
+     * 
+     * @return bool
+     */
+    protected function classIsNamespaced( $tokens ) {
+        
+        foreach ( $tokens as $token => $value ) {
+            
+            if ( $value['type'] == 'T_NAMESPACE' ) {
+                return true;
+            }
+            
+            // try and fail fast, if we hit much else apart from the namespace
+            // then there can't be a namespace
+            if ( $value['type'] == 'T_STRING' ) {
+                return false;
+            }
+            
+        }
+        
+        return false;
+        
+    }
 
     /**
-     * 
      * @param PHP_CodeSniffer_File $phpcsFile File we're sniffing
      * @param array $tokens All tokens
      * @param type $index Token index
      * @param type $stackPtr Current stack pointer
      */
-    private function sniffForPackage( PHP_CodeSniffer_File $phpcsFile, array $tokens, $index, $stackPtr ) {
+    protected function sniffForPackage( PHP_CodeSniffer_File $phpcsFile, array $tokens, $index, $stackPtr ) {
 
         while ( true && isset($tokens[$index]) ) {
             if ( strstr($tokens[$index]['content'],'@package') !== false ) {

--- a/tests/data/php/shouldpass/NamespacedClass.php
+++ b/tests/data/php/shouldpass/NamespacedClass.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace BoxUK\Test;
+
+/**
+ * No package annotation because class is namespaced.
+ * 
+ */
+class NamespacedClass {}

--- a/tests/php/CodingStandardTest.php
+++ b/tests/php/CodingStandardTest.php
@@ -89,6 +89,10 @@ class CodingStandardTest extends PHPUnit_Framework_TestCase {
     public function testFileWithCorrectCodingStandardsDoesNotReportAnyErrors() {
         $this->assertSniffPasses( 'ShouldPass' );
     }
+    
+    public function testPackageAnnotationNotRequiredIfClassIsNamespaced() {
+        $this->assertSniffPasses( 'NamespacedClass' );
+    }
 
     ////////////////////////////////////////////////////////////////////////////
     


### PR DESCRIPTION
If the docs generator doesn't allow this then we can fix it up to support it, but for the moment it's duplicating the namespace right next to it which is a bit silly.
